### PR TITLE
ROZPR-5948 Fix json parse bug

### DIFF
--- a/salesforceService.js
+++ b/salesforceService.js
@@ -92,7 +92,7 @@ module.exports = {
         const refundReason = getRefundReasonFromRefundedCharge(charge);
         const refundId = getRefundIdFromRefundedCharge(charge);
         const refundData = {
-            refund: {
+            stripeRefund: {
                 id: refundId,
                 paymentIntentId: charge.payment_intent,
                 created: dateChecker.convertUnixTimestampToDate(charge.created),


### PR DESCRIPTION
# Description
This PR is a fix for [ROZPR-5948 task](https://app.clickup.com/t/4540126/ROZPR-5948) as there was a json parse error due to mismatch between object name and argument name passed to salesforce endpoint.

# Changes
- Change object name to match salesforce StripeRefundController argument name

# Issues Closed
- [ROZPR-5948 task](https://app.clickup.com/t/4540126/ROZPR-5948) 
