### PR TITLE
change the time used for failed payments

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,14 @@ app.post('/webhook', bodyParser.raw({ type: 'application/json' }), async (reques
     case 'payment_intent.payment_failed':
         console.log(`Processing event type ${event.type}`);
         intent = event.data.object;
+        /**
+         * In almost every scenerario these two dates are the same, but if it's a failed payment it's possible
+         * that it's a recharge and the date of the payment will be set as the initial payment intent collection
+         * attempt date.
+         *
+         * We want to represent the date of the actual collection on the payment object in salesforce.
+        * */
+        intent.created = event.created;
         await handlePayment(intent);
         break;
     case 'charge.refunded':


### PR DESCRIPTION
# Short version (Just read this bit if you don't want to read all the detail, apologies the PR description is so long!)
I have changed the payment/opportunity/recurring donation creation date to be the time in which the stripe payment_intent.payment_failed event is created rather than the time the original payment intent object was created. 

This means if a payment intent object is invoked multiple times to recharge a recurring donor then we don't use the same date for each recharge.

# Description
Through testing it was highlighted that each recharge of a recurring donation uses the original monthly charge creation date rather than the date of each actual recharge attempt. 

We have a donor https://dashboard.stripe.com/payments/pi_3NZLl7HPCO7LDipn0klWAEeX who in salesforce has this recurring donation generated from an incoming payment: 
https://otwarteklatki--datacopy.sandbox.lightning.force.com/lightning/r/npe03__Recurring_Donation__c/a09Fg000000hPBFIA2/view

It has two donations attached to it: 
https://otwarteklatki--datacopy.sandbox.lightning.force.com/lightning/r/006Fg000005BBdFIAW/view
https://otwarteklatki--datacopy.sandbox.lightning.force.com/lightning/r/006Fg000005DBpEIAW/view

Both for the date of 29th of July, which is the date the initial donation is meant to be on.

In stripe we see: 
![image](https://github.com/otwarteklatki/ok-sf-stripe-webhooks/assets/6373588/ced2cfdb-7c5c-4e2e-8ebf-def53427a16b)

The screenshot above shows the time in CET from filip who is an hour ahead of me, which is why it’s the 30th not the 29th in the initial payment. Also bare in mind that the integration was turned on on the 17th so we shouldn't expect to see anything before that.

What we want to see in stripe is
Opp -> 29th/30th of July
Failed payment 4 -> 18th of august
Failed payment 5 -> 20th of august

Details for failed payment 4:

On the 18th this payment_intent.payment_failed event fired https://dashboard.stripe.com/events/evt_3NZLl7HPCO7LDipn08N9tiMV

And successfully sent data to our webhook provider (see link above for details)
"event.created": 1692319442, // webhook event creation date = Friday, 18 August 2023 00:44:02
"event.data.object.created": 1690670233, // payment intent creation date = Saturday, 29 July 2023 22:37:13

So I've swapped the dates used for failed payments. I believe this will mean we use the event created data for creating new payments and opportunities but when a payment comes it which can be attached to an existing opportunity it will not effect the date on the existing opportunity and use the created date for the new payment. 

# Changes
- added one line which reassigns the date to use the webhook event creation date

# Testing
I tested/checked our Stripe payment scenarios and if the event created time is what we expected. 

| Type                       | Method                         | Event created                               | Object created                              | URL                                                                    | Do we expect it to be possible there is a difference | Is there a difference |
|----------------------------|--------------------------------|---------------------------------------------|---------------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------|---------------------|
| payment_intent.payment_failed  | Card - one off                 | 1692957753 -> Friday, 25 August 2023 10:02:33 | 1692957752 -> Friday, 25 August 2023 10:02:32 | [URL](https://dashboard.stripe.com/test/events/evt_3NiwqaHPCO7LDipn1XyIjyhS) | no                                                  | no                  |
| payment_intent.payment_failed  | BLIK                           | 1692911264 -> Thursday, 24 August 2023 21:07:44 | 1692911219 -> Thursday, 24 August 2023 21:06:59 | [URL](https://dashboard.stripe.com/events/evt_3Nikk3HPCO7LDipn1A2Pc2LU)     | no                                                  | no                  |
| payment_intent.payment_failed  | Card - recurring new           | 1692958171 -> Friday, 25 August 2023 10:09:31 | 1692958157-> Friday, 25 August 2023 10:09:17  | [URL](https://dashboard.stripe.com/test/events/evt_3Niwx7HPCO7LDipn1rihZPnt) | no                                                  | no                  |
| payment_intent.payment_failed  | Card - Existing subscription payment | 1692952883 -> Friday, 25 August 2023 08:41:23 | 1691292810 -> Sunday, 6 August 2023 03:33:30  | [URL](https://dashboard.stripe.com/events/evt_3NbxigHPCO7LDipn1EMmk5xf)     | yes                                                 | yes                 |
| payment_intent.payment_success | Card - one off                 | 1692887726 -> Thursday, 24 August 2023 14:35:26 | 1692887724 -> Thursday, 24 August 2023 14:35:24 | [URL](https://dashboard.stripe.com/events/evt_3Nied6HPCO7LDipn1CGVR4gy)     | no                                                  | no                  |
| payment_intent.payment_success | BLIK                           | 1692942630 -> Friday, 25 August 2023 05:50:30 | 1692942623 -> Friday, 25 August 2023 05:50:23  | [URL](https://dashboard.stripe.com/events/evt_3NisuZHPCO7LDipn0TzHyo02)     | no                                                  | no                  |
| payment_intent.payment_success | Card - recurring new           | 1692431074 -> Saturday, 19 August 2023 07:44:34 | 1692431041 -> Saturday, 19 August 2023 07:44:01 | [URL](https://dashboard.stripe.com/events/evt_3NgjpFHPCO7LDipn1DKjLP2g)     | no                                                  | no                  |
| payment_intent.payment_success | Card - Existing subscription payment | 1692769191 -> Wednesday, 23 August 2023 05:39:51 | 1691588067 -> Wednesday, 9 August 2023 13:34:27  | [URL](https://dashboard.stripe.com/events/evt_3NdCWtHPCO7LDipn0lHievfR)     | yes                                                 | yes                 |

I also tested if the time in which we ask stripe sends the webhook has an effect on the event creation time it sends us
| Type                       | Method       | Event created                             | Object created                              | URL                                                                    | Webhook sent datetime |
|----------------------------|--------------|-------------------------------------------|---------------------------------------------|-------------------------------------------------------------------------|----------------------|
| payment_intent.payment_failed  | Card - one off | 1692957753 -> Friday, 25 August 2023 10:02:33 | 1692957752 -> Friday, 25 August 2023 10:02:32 | [URL](https://dashboard.stripe.com/test/events/evt_3NiwqaHPCO7LDipn1XyIjyhS) | 25 Aug, 12:02       |
| payment_intent.payment_failed  | Card - one off | 1692957753 -> Friday, 25 August 2023 10:02:33  | 1692957752 -> Friday, 25 August 2023 10:02:32  | [URL](https://dashboard.stripe.com/test/events/evt_3NiwqaHPCO7LDipn1XyIjyhS) | 25 Aug, 13:11       |

### Implications on downstream methods
This new created date will be used in the following contexts assuming the payment we're processing failed: 
- title for new recurring donation opportunities
- title for new recurring donations
- title for new one-off opportunities
- the npsp__StartDate__c for a new recurring donation
- the opportunity CloseDate for a new recurring donation opportunities 
- the opportunity CloseDate for a new one-off donation opportunities
- the payment object (npe01__OppPayment__c) fields: npe01__Payment_Date__c, otwarteklatki__Payment_Time__c

# Issues Closed
https://app.clickup.com/t/4540126/ROZPR-12385